### PR TITLE
Add content permissions migration for Editor role

### DIFF
--- a/config/datocms/migrations/1732633588_contentPermissionsMember.ts
+++ b/config/datocms/migrations/1732633588_contentPermissionsMember.ts
@@ -1,0 +1,68 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Update permissions for environment in role Editor');
+  await client.roles.updateCurrentEnvironmentPermissions('301184', {
+    positive_item_type_permissions: {
+      add: [
+        {
+          item_type: 'ByoMKdCkSp6T10UjQm26wg',
+          action: 'read',
+          on_creator: 'self',
+        },
+        {
+          item_type: 'ByoMKdCkSp6T10UjQm26wg',
+          action: 'update',
+          on_creator: 'self',
+          localization_scope: 'all',
+        },
+        {
+          item_type: 'ByoMKdCkSp6T10UjQm26wg',
+          action: 'publish',
+          on_creator: 'self',
+          localization_scope: 'all',
+        },
+        {
+          item_type: 'BdrPCTMrRGWPtEqBP0nSYg',
+          action: 'read',
+          on_creator: 'anyone',
+        },
+        {
+          item_type: 'Q04RdQnVQw-xei_UK8GzjA',
+          action: 'read',
+          on_creator: 'anyone',
+        },
+        {
+          item_type: 'UxqkfkpETnWtRgn2iP6Vhg',
+          action: 'read',
+          on_creator: 'anyone',
+        },
+        {
+          item_type: 'Bc_RFLXqQDG5Eb0SJblw5Q',
+          action: 'read',
+          on_creator: 'self',
+        },
+        {
+          item_type: 'Bc_RFLXqQDG5Eb0SJblw5Q',
+          action: 'update',
+          on_creator: 'self',
+          localization_scope: 'all',
+        },
+        {
+          item_type: 'Bc_RFLXqQDG5Eb0SJblw5Q',
+          action: 'delete',
+          on_creator: 'self',
+        },
+      ],
+    },
+    positive_upload_permissions: {
+      add: [
+        { action: 'read', on_creator: 'anyone' },
+        { action: 'all', on_creator: 'self', localization_scope: 'all' },
+      ],
+      remove: [
+        { action: 'all', on_creator: 'anyone', localization_scope: 'all' },
+      ],
+    },
+  });
+}


### PR DESCRIPTION
# Changes

Adds content permissions migration for Editor role

# Associated issue

https://trello.com/c/bz0Vn7SY/18-agency-profiel-beheren

# How to test

In de 'permissions' environment in Dato:
Voeg jezelf (luuk@voorhoede.nl) toe als creator van een 'member' record en log in met je eigen account. Je zou nu alleen je eigen dingen moeten kunnen editen.
