### PR TITLE
Adjust heading sizes in text block to match design

### DIFF
--- a/src/blocks/TextBlock/nodes/Heading.astro
+++ b/src/blocks/TextBlock/nodes/Heading.astro
@@ -1,8 +1,12 @@
 ---
-import type { Heading } from 'datocms-structured-text-utils';
+import type { Heading as HeadingType } from 'datocms-structured-text-utils';
+import {
+  Heading as HeadingComponent,
+  type HeadingProps,
+} from '@components/Heading';
 
 interface Props {
-  node: Heading;
+  node: HeadingType;
 }
 
 const { node } = Astro.props;
@@ -10,8 +14,21 @@ const { node } = Astro.props;
 // H1 is reserved for the page title, so we start at H2
 const minimumLevel = 2;
 const defaultLevel = 2;
-const level = Math.max(minimumLevel, (node.level || defaultLevel));
+const level = Math.max(
+  minimumLevel,
+  node.level || defaultLevel
+) as HeadingProps['level'];
 
-const Tag = `h${level}`;
+// This is a mapping of the heading level to the display level
+// used specifically in text blocks to only use the smaller variants
+// of the headings
+const levelMap: Record<number, HeadingProps['displayLevel']> = {
+  2: 4,
+  3: 5,
+  4: 6,
+};
 ---
-<Tag><slot /></Tag>
+
+<HeadingComponent level={level} displayLevel={levelMap[level as number]}>
+  <slot />
+</HeadingComponent>

--- a/src/components/Heading/Heading.css
+++ b/src/components/Heading/Heading.css
@@ -31,12 +31,14 @@
   font-weight: 400;
   line-height: 2rem;
   letter-spacing: 0rem;
+  text-transform: none;
 }
 
 .heading--5 {
   font-size: 1.125rem;
   line-height: 2rem;
   letter-spacing: 0rem;
+  text-transform: none;
 }
 
 .heading--6 {
@@ -44,6 +46,7 @@
   font-weight: 400;
   line-height: 2rem;
   letter-spacing: 0rem;
+  text-transform: none;
 }
 
 @media screen and (min-width: 890px) {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -2,11 +2,12 @@ import clsx from 'clsx';
 import type { ElementType, ReactNode } from 'react';
 import './Heading.css';
 
-interface HeadingProps {
+export interface HeadingProps {
   children: ReactNode;
   className?: string;
   displayLevel?: 1 | 2 | 3 | 4 | 5 | 6;
   level: 1 | 2 | 3 | 4 | 5 | 6 | 'p' | 'span';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 

--- a/src/components/Heading/index.ts
+++ b/src/components/Heading/index.ts
@@ -1,1 +1,1 @@
-export { Heading } from './Heading';
+export { Heading, type HeadingProps } from './Heading';


### PR DESCRIPTION
# Changes

Adjusts heading sizes in text block so it matches design.

Note that I also adjusted allowed headings in text block in Dato:
![image](https://github.com/user-attachments/assets/bbd4d466-9521-45ef-ad81-8e2c5e41ca2c)


# Associated issue

https://trello.com/c/IGSds6VY/51-align-typography-in-text-block-with-design

# How to test

https://heading-sizes.dda-website.pages.dev/lid-worden/
