### PR TITLE
Fix: TeamMemberCard links

### DIFF
--- a/src/blocks/TeamMemberCard/TeamMemberCard.tsx
+++ b/src/blocks/TeamMemberCard/TeamMemberCard.tsx
@@ -36,7 +36,6 @@ export const TeamMemberCard = ({ member }: Props) => {
           icon="arrow-up-right"
           level="secondary"
           variant="large"
-          targetArea="parent"
         >
           LinkedIn
           <span className="a11y-sr-only">


### PR DESCRIPTION
# Changes

- Fixes the unclickable links in the team member cards

# How to test

1. Open preview link
2. Navigate to `/over-ons/`
3. Scroll down to the team members and click the links

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] ~I have made updated relevant documentation files (in project README, docs/, etc)~
- [ ] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
