### PR TITLE
Partner link

### DIFF
--- a/config/datocms/migrations/1747815858_partnerLink.ts
+++ b/config/datocms/migrations/1747815858_partnerLink.ts
@@ -1,0 +1,23 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Update existing fields/fieldsets');
+
+  console.log(
+    'Update Single link field "Page" (`page`) in model "\uD83E\uDD1D Partner" (`partner`)',
+  );
+  await client.fields.update('TiBAVelkQgesypaKiELdJw', {
+    validators: {
+      item_item_type: {
+        on_publish_with_unpublished_references_strategy: 'fail',
+        on_reference_unpublish_strategy: 'delete_references',
+        on_reference_delete_strategy: 'delete_references',
+        item_types: [
+          'T5DMLHeUTF2ub3p2Wx-CBw',
+          'WsNJp5eaRz2-QZserzWOTw',
+          'cgpNpUIYRY2eQa_E0u-7SQ',
+        ],
+      },
+    },
+  });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'main';
+export const datocmsEnvironment = 'partner-link';
 export const datocmsBuildTriggerId = '30535';

--- a/src/blocks/EventCard/EventCard.tsx
+++ b/src/blocks/EventCard/EventCard.tsx
@@ -8,7 +8,20 @@ import { t } from '@lib/i18n';
 import type { EventCardFragment } from '@lib/types/datocms';
 import { SRCImage } from 'react-datocms';
 
-export const EventCard = ({ event, priority }: { event: EventCardFragment, priority?: boolean }) => {
+export function getEventUrl(event: EventCardFragment): string {
+  if (event.details?.__typename === 'ExternalEventRecord') {
+    return event.details.link;
+  }
+  return `/events/${event.details?.slug}/`;
+}
+
+export const EventCard = ({
+  event,
+  priority,
+}: {
+  event: EventCardFragment;
+  priority?: boolean;
+}) => {
   return (
     <Card>
       {event.image.responsiveImage && (
@@ -38,11 +51,7 @@ export const EventCard = ({ event, priority }: { event: EventCardFragment, prior
           icon="arrow-right"
           level="secondary"
           variant="large"
-          href={
-            event.details.__typename === 'ExternalEventRecord'
-              ? event.details.link
-              : `./${event.details.slug}/`
-          }
+          href={getEventUrl(event)}
           targetArea="parent"
         >
           {t('details')}

--- a/src/blocks/PartnerBanner/PartnerBanner.tsx
+++ b/src/blocks/PartnerBanner/PartnerBanner.tsx
@@ -1,10 +1,38 @@
+import { SRCImage } from 'react-datocms';
 import { Button } from '@components/Button';
 import { Heading } from '@components/Heading';
 import { ImageParade, ImageParadeItem } from '@components/ImageParade';
+import { getEventUrl } from '@blocks/EventCard/EventCard';
+import type {
+  EventCardFragment,
+  PartnerLogoFragment,
+} from '@lib/types/datocms';
 import { t } from '@lib/i18n';
-import type { PartnerLogoFragment } from '@lib/types/datocms';
-import { SRCImage } from 'react-datocms';
 import './PartnerBanner.css';
+
+function getPartnerUrl(partner: PartnerLogoFragment): string {
+  if (partner.page?.__typename === 'ExternalLinkRecord') {
+    return partner.page.url ?? '';
+  }
+
+  if (partner.page?.__typename === 'PageRecord') {
+    return `/${partner.page?.slug}/`;
+  }
+
+  if (partner.page?.__typename === 'EventRecord') {
+    return getEventUrl(partner.page as EventCardFragment);
+  }
+
+  return '';
+}
+
+function getPartnerTarget(partner: PartnerLogoFragment): string | undefined {
+  if (partner.page?.__typename === 'ExternalLinkRecord') {
+    return '_blank';
+  }
+
+  return undefined;
+}
 
 export const PartnerBanner = ({
   partners,
@@ -32,7 +60,8 @@ export const PartnerBanner = ({
               partner.logo.responsiveImage && (
                 <ImageParadeItem key={partner.logo.id}>
                   <a
-                    href={`/${partner.page?.slug}/`}
+                    href={getPartnerUrl(partner)}
+                    target={getPartnerTarget(partner)}
                     className="partner-banner__logo"
                   >
                     <SRCImage

--- a/src/blocks/PartnerBanner/PartnerLogo.fragment.graphql
+++ b/src/blocks/PartnerBanner/PartnerLogo.fragment.graphql
@@ -15,6 +15,24 @@ fragment PartnerLogo on PartnerRecord {
     }
   }
   page {
-    slug
+    __typename
+    ... on ExternalLinkRecord {
+      title
+      url
+    }
+    ... on PageRecord {
+      slug
+    }
+    ... on EventRecord {
+      details {
+        __typename
+        ... on InternalEventRecord {
+          slug
+        }
+        ... on ExternalEventRecord {
+          link
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# Partner link

Adds support for linking to different types of content from a partner logo:
- External links
- Pages
- Events (internal and external)

# Changes

- Refactors `EventCard` to extract `getEventUrl()` function
- Adds `getPartnerUrl()` and `getPartnerTarget()` helpers in `PartnerBanner`
- Updates `PartnerBanner` to support multiple link types (page, external, event)
- Updates GraphQL fragment to include `__typename` and required fields for all supported types

# Associated issue

https://trello.com/c/8agTcCQw/103-toevoegen-partner-doorlinken-footer

# How to test

1. Open the preview link for the branch
2. Navigate to a page with a PartnerBanner
3. Verify that:
   - Partner logos link correctly to internal pages
   - Partner logos with external links open in a new tab
   - Partner logos linked to events route correctly (internal/external)
4. Check that EventCards still render and link correctly

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [ ] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->