### PR TITLE
Update event handling to support multi-day events

### DIFF
--- a/config/datocms/migrations/1747817814_mutiDayEvent.ts
+++ b/config/datocms/migrations/1747817814_mutiDayEvent.ts
@@ -1,0 +1,32 @@
+import { Client } from '@datocms/cli/lib/cma-client-node';
+
+export default async function (client: Client) {
+  console.log('Creating new fields/fieldsets');
+
+  console.log(
+    'Create Date field "End Date" (`end_date`) in model "\uD83D\uDCC6 Event" (`event`)',
+  );
+  await client.fields.create('WsNJp5eaRz2-QZserzWOTw', {
+    id: 'GRWl8sW1RXmjBr5x5874UA',
+    label: 'End Date',
+    field_type: 'date',
+    api_key: 'end_date',
+    hint: 'Optional \u2014 fill in only for multi-day events',
+    appearance: { addons: [], editor: 'date_picker', parameters: {} },
+  });
+
+  console.log('Update existing fields/fieldsets');
+
+  console.log(
+    'Update Date field "End Date" (`end_date`) in model "\uD83D\uDCC6 Event" (`event`)',
+  );
+  await client.fields.update('GRWl8sW1RXmjBr5x5874UA', { position: 4 });
+
+  console.log(
+    'Update Date field "Start Date" (`start_date`) in model "\uD83D\uDCC6 Event" (`event`)',
+  );
+  await client.fields.update('ZVd_2vrpRre1mx23DlHHcg', {
+    label: 'Start Date',
+    api_key: 'start_date',
+  });
+}

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'multi-day-events';
+export const datocmsEnvironment = 'multi-day-event';
 export const datocmsBuildTriggerId = '30535';

--- a/datocms-environment.ts
+++ b/datocms-environment.ts
@@ -3,5 +3,5 @@
  * @see docs/getting-started.md on how to use this file
  * @see docs/decision-log/2023-10-24-datocms-env-file.md on why file is preferred over env vars
  */
-export const datocmsEnvironment = 'embed-in-text-block';
+export const datocmsEnvironment = 'multi-day-events';
 export const datocmsBuildTriggerId = '30535';

--- a/src/blocks/EventCard/EventCard.fragment.graphql
+++ b/src/blocks/EventCard/EventCard.fragment.graphql
@@ -14,7 +14,8 @@ fragment EventCard on EventRecord {
       width
     }
   }
-  date
+  startDate
+  endDate
   location
   theme {
     name

--- a/src/blocks/EventCard/EventCard.tsx
+++ b/src/blocks/EventCard/EventCard.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@components/Button';
 import { Card, CardContent, CardFooter, CardImage } from '@components/Card';
+import { EventDate } from '@components/EventDate';
 import { Heading } from '@components/Heading';
 import { TagList, TagListItem } from '@components/Tag';
 import { Text } from '@components/Text';
-import { formatDate } from '@lib/date';
 import { t } from '@lib/i18n';
 import type { EventCardFragment } from '@lib/types/datocms';
 import { SRCImage } from 'react-datocms';
@@ -33,12 +33,12 @@ export const EventCard = ({
         <TagList>
           {event.theme?.name && <TagListItem>{event.theme?.name}</TagListItem>}
         </TagList>
-        {(event.date || event.location) && (
+        {(event.startDate || event.location) && (
           <Text variant="subtext">
-            {event.date && (
-              <time dateTime={event.date}>{formatDate(event.date)}</time>
+            {event.startDate && (
+              <EventDate startDate={event.startDate} endDate={event.endDate} />
             )}
-            {event.date && event.location && <>&nbsp;/&nbsp;</>}
+            {event.startDate && event.location && <>&nbsp;/&nbsp;</>}
             {event.location && event.location}
           </Text>
         )}

--- a/src/blocks/EventList/EventList.tsx
+++ b/src/blocks/EventList/EventList.tsx
@@ -31,7 +31,7 @@ export const loader = async ({
   searchParams,
   fixedFilters = {},
   defaultPageSize,
-  orderBy = 'date_ASC' as EventModelOrderBy,
+  orderBy = 'startDate_ASC' as EventModelOrderBy,
 }: {
   searchParams: Record<string, string>;
   fixedFilters?: EventModelFilter;
@@ -182,7 +182,6 @@ export const EventList = withQueryClientProvider(
           />
         )}
 
-        
         {presentation === 'list' ? (
           <List ref={listRef} data={data.events} />
         ) : (

--- a/src/blocks/EventList/components/List.tsx
+++ b/src/blocks/EventList/components/List.tsx
@@ -13,7 +13,7 @@ import { Heading } from '@components/Heading';
 import { Button } from '@components/Button';
 import { Text } from '@components/Text';
 import { Tag } from '@components/Tag';
-import { EventDate } from '@components/EventDate/EventDate';
+import { EventDate } from '@components/EventDate';
 
 type Props = {
   data: EventsData['events'];

--- a/src/blocks/EventList/components/List.tsx
+++ b/src/blocks/EventList/components/List.tsx
@@ -2,14 +2,18 @@ import type { EventsData } from '../EventList';
 
 import { forwardRef } from 'react';
 import { t } from '@lib/i18n';
-import { formatDate } from '@lib/date';
 import clsx from 'clsx';
 
-import { DataList, DataListItem, DataListItemFooter } from '@components/DataList';
+import {
+  DataList,
+  DataListItem,
+  DataListItemFooter,
+} from '@components/DataList';
 import { Heading } from '@components/Heading';
 import { Button } from '@components/Button';
 import { Text } from '@components/Text';
 import { Tag } from '@components/Tag';
+import { EventDate } from '@components/EventDate/EventDate';
 
 type Props = {
   data: EventsData['events'];
@@ -32,7 +36,7 @@ export const List = forwardRef<HTMLUListElement, Props>(({ data }, ref) => {
           </Heading>
           <DataListItemFooter>
             <Text variant="subtext">
-              <time dateTime={item.date}>{formatDate(item.date)}</time>
+              <EventDate startDate={item.startDate} endDate={item.endDate} />
               {item.location && ` / ${item.location}`}
             </Text>
             <Button

--- a/src/components/EventDate/EventDate.tsx
+++ b/src/components/EventDate/EventDate.tsx
@@ -1,0 +1,14 @@
+import { formatDate } from '@lib/date';
+
+export type EventDateProps = {
+  startDate: string;
+  endDate?: string | null;
+};
+
+export const EventDate = ({ startDate, endDate }: EventDateProps) => {
+  if (!startDate) return null;
+  if (!endDate)
+    return <time dateTime={startDate}>{formatDate(startDate)}</time>;
+
+  return <span>{formatDate(startDate, endDate)}</span>;
+};

--- a/src/components/EventDate/index.ts
+++ b/src/components/EventDate/index.ts
@@ -1,0 +1,1 @@
+export * from './EventDate';

--- a/src/components/EventsSection/EventsSection.tsx
+++ b/src/components/EventsSection/EventsSection.tsx
@@ -9,7 +9,7 @@ import { Column, Grid, type SpanOptions } from '@components/Grid';
 import { Heading } from '@components/Heading';
 import { Tag } from '@components/Tag';
 import { Text } from '@components/Text';
-import { formatDate } from '@lib/date';
+import { EventDate } from '@components/EventDate';
 import { t } from '@lib/i18n';
 import type { EventCardFragment } from '@lib/types/datocms';
 import './EventsSection.css';
@@ -47,9 +47,10 @@ export const EventsSection = ({ events }: EventsSectionProps) => {
                   </Heading>
                   <DataListItemFooter>
                     <Text variant="subtext">
-                      <time dateTime={event.date}>
-                        {formatDate(event.date)}
-                      </time>
+                      <EventDate
+                        startDate={event.startDate}
+                        endDate={event.endDate}
+                      />
                       {event.location && ` / ${event.location}`}
                     </Text>
                     <Button

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -9,9 +9,16 @@ export const getToday = () => {
   return today;
 };
 
-export const formatDate = (date: string | Date) =>
-  new Date(date).toLocaleDateString(getLocale(), {
-    day: 'numeric',
-    month: 'short',
+export const formatDate = (startDate: string, endDate?: string) => {
+  if (!startDate) return '';
+
+  const fmt = new Intl.DateTimeFormat(getLocale(), {
     year: 'numeric',
+    month: 'short',
+    day: 'numeric',
   });
+
+  if (!endDate) return fmt.format(new Date(startDate));
+
+  return fmt.formatRange(new Date(startDate), new Date(endDate));
+};

--- a/src/pages/_index.query.graphql
+++ b/src/pages/_index.query.graphql
@@ -34,8 +34,8 @@ query HomePage($locale: SiteLocale!, $today: Date!) {
 
   events: allEvents(
     first: 6
-    orderBy: date_ASC
-    filter: { date: { gte: $today } }
+    orderBy: startDate_ASC
+    filter: { startDate: { gte: $today } }
   ) {
     ...EventCard
   }

--- a/src/pages/events/[slug]/_eventPage.query.graphql
+++ b/src/pages/events/[slug]/_eventPage.query.graphql
@@ -6,7 +6,8 @@ query EventPage($locale: SiteLocale = nl, $slug: String!) {
     filter: { details: { any: { internalEvent: { slug: { eq: $slug } } } } }
   ) {
     title
-    date
+    startDate
+    endDate
     location
     image {
       responsiveImage(imgixParams: { fit: crop, h: 416, auto: format }) {

--- a/src/pages/events/[slug]/index.astro
+++ b/src/pages/events/[slug]/index.astro
@@ -17,11 +17,10 @@ import {
 import { Heading } from '@components/Heading';
 import { Button } from '@components/Button';
 import { Text } from '@components/Text';
-import { SRCImage } from 'react-datocms';
+import { EventDate } from '@components/EventDate';
 import { Column, Grid } from '@components/Grid';
-import { formatDate } from '@lib/date';
 import TextBlock from '@blocks/TextBlock/TextBlock.astro';
-import { EventDate } from '@components/EventDate/EventDate';
+import { SRCImage } from 'react-datocms';
 
 setCacheControl(Astro.response);
 
@@ -73,9 +72,11 @@ if (!page || page.details.__typename !== 'InternalEventRecord') {
 
   <Grid className="event" rowGap={40} columnGap={32}>
     <Column span={{ mobile: 12, tablet: 5 }}>
-      <Text variant="subtext"
-      >{page.title} - <time datetime={page.date}>{formatDate(page.date)}</time
-        >, {page.location}</Text
+      <Text variant="subtext">
+        {page.title} - <EventDate
+          startDate={page.startDate}
+          endDate={page.endDate}
+        />, {page.location}</Text
       >
     </Column>
 

--- a/src/pages/events/[slug]/index.astro
+++ b/src/pages/events/[slug]/index.astro
@@ -21,6 +21,7 @@ import { SRCImage } from 'react-datocms';
 import { Column, Grid } from '@components/Grid';
 import { formatDate } from '@lib/date';
 import TextBlock from '@blocks/TextBlock/TextBlock.astro';
+import { EventDate } from '@components/EventDate/EventDate';
 
 setCacheControl(Astro.response);
 
@@ -49,11 +50,10 @@ if (!page || page.details.__typename !== 'InternalEventRecord') {
       <Heading level={1}>{page.title}</Heading>
     </PageTitleHeader>
     <PageTitleContent>
-      <Text variant="subtext"
-      ><time datetime={page.date}>{formatDate(page.date)}</time> / {
-          page.location
-        }</Text
-      >
+      <Text variant="subtext">
+        <EventDate startDate={page.startDate} endDate={page.endDate} />
+        {' '}/ {page.location}
+      </Text>
     </PageTitleContent>
   </PageTitle>
 

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -53,9 +53,9 @@ if (!page) {
     queryKey="events"
     defaultPageSize={15}
     fixedFilters={{
-      date: { gte: today },
+      startDate: { gte: today },
     }}
-    orderBy={'date_ASC' as EventModelOrderBy}
+    orderBy={'startDate_ASC' as EventModelOrderBy}
     presentation="grid"
   />
 
@@ -69,9 +69,9 @@ if (!page) {
       defaultPageSize={3}
       showFilter={false}
       fixedFilters={{
-        date: { lt: today },
+        startDate: { lt: today },
       }}
-      orderBy={'date_DESC' as EventModelOrderBy}
+      orderBy={'startDate_DESC' as EventModelOrderBy}
     />
   </section>
 


### PR DESCRIPTION
## Description

- Update `EventCard` and `EventList` components to use `startDate` and `endDate` instead of `date`.
- Modify queries and filters to order and filter events by `startDate`.
- Refactor date formatting to handle ranges for multi-day events.
- Add `EventDate` component for consistent rendering of event dates.

## Changes

- Adds `end_date` field to DatoCMS Event model via migration.
- Updates all frontend components and queries to use `startDate` and `endDate`.
- Introduces new utility function in `lib/date.ts` for date range formatting.
- Replaces all instances of `date` usage in queries, components, and pages.
- Adds and exports new `EventDate` component.

## Associated issue

https://trello.com/c/vnXxpvkU/104-events-van-meerdere-dagen

## How to test

1. Run the project with `datocmsEnvironment` set to `multi-day-events`.
2. Visit the homepage and the events overview page.
3. Verify that:
   - Upcoming events are ordered by `startDate`.
   - Event cards and lists display a date range when `endDate` is present.
   - Single-day events still show correctly.
4. Open a specific event detail page and check that `startDate`/`endDate` and location render as expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have updated relevant documentation files (in project README, docs/, etc)
- [x] I have added a decision log entry if the change affects the architecture or changes a significant technology
- [x] I have notified a reviewer

---

Remember, contributions to this repository should follow its contributing guidelines.