### PR TITLE
Fix: New build cause data shuffles

### DIFF
--- a/src/lib/react-query.tsx
+++ b/src/lib/react-query.tsx
@@ -6,7 +6,7 @@ import {
   QueryClientProvider,
   type DehydratedState,
 } from '@tanstack/react-query';
-import { type ComponentType } from 'react';
+import { type ComponentType, useRef } from 'react';
 
 export type QueryClientProviderProps = {
   initialState: DehydratedState;
@@ -22,23 +22,24 @@ export type QueryClientProviderComponentProps = Omit<
 export function withQueryClientProvider<T extends object>(
   WrappedComponent: ComponentType<T>,
 ) {
-  // Create a new QueryClient instance
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-        refetchOnMount: true,
-        placeholderData: keepPreviousData,
-      },
-    },
-  });
-
-  // Return a new component that includes the QueryClientProvider
   return function WithQueryClientProviderComponent(
     props: T & QueryClientProviderProps,
   ) {
+    const queryClientRef = useRef<QueryClient | null>(null);
+    if (!queryClientRef.current) {
+      queryClientRef.current = new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            refetchOnMount: true,
+            placeholderData: keepPreviousData,
+          },
+        },
+      });
+    }
+
     return (
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={queryClientRef.current}>
         <HydrationBoundary state={props.initialState}>
           <WrappedComponent {...props} />
         </HydrationBoundary>


### PR DESCRIPTION
DDA mentioned that new items don't get published properly. Links get matched to the wrong items.

Looking into this I thought this may had something to do with caching. Explaining the situation to AI it mentioned that the problem would be the query client setting. Which is not properly stored or tracked. Seems to me like it could be. So I improved the query client setting.

## Changes

- Move QueryClient creation into the component and guard with a useRef to initialize once.
- Use a ref to store the QueryClient instance and reuse it on subsequent renders.
- Pass queryClientRef.current to QueryClientProvider.

## Associated issue

Issue is in Slack.

## How to test

1. Open preview link
2. Navigate to `/vacatures/`
3. Vacancies should load
4. Try filtering
5. Filters should be applied

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have made updated relevant documentation files (in project README, docs/, etc)
- [ ] ~I have added a decision log entry if the change affects the architecture or changes a significant technology~
- [x] I have notified a reviewer

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
