### PR TITLE
fix: hide AI internships without a linked member from the list

### DIFF
--- a/src/blocks/AiInternshipList/AiInternshipList.tsx
+++ b/src/blocks/AiInternshipList/AiInternshipList.tsx
@@ -80,9 +80,13 @@ export const loader = async (
     orderBy: '_createdAt_DESC',
   });
 
+  // internships without a linked member have no detail page (404s), so
+  // hide them from the list
+  const linkedItems = items.filter((item) => item.company.length > 0);
+
   // shuffle for fairness, then push filled internships to the end while
   // keeping the shuffled order within each group (Array.sort is stable)
-  const shuffled = shuffle<AiInternshipItemFragment>(items, seed);
+  const shuffled = shuffle<AiInternshipItemFragment>(linkedItems, seed);
 
   return {
     items: shuffled.sort(


### PR DESCRIPTION
## Summary
- AI internship records whose company/member link had been removed in DatoCMS (`_allReferencingMembers` empty) still appeared in the vacatures list, but 404'd when clicked, since the detail page hard-requires that link.
- The list loader now filters out any internship with no linked member before rendering, so the frontend list only ever shows clickable results.

## Context
This does not clean up the underlying orphaned records in DatoCMS — those still exist and should be removed/relinked separately. Currently 10 known orphaned records (Framna x4, Kaliber x2, 4net x2, Norday, PowerKraut) in the `release-ai-internship-filled` environment.

## Test plan
- [x] `git diff` reviewed — change is a single filter added to the existing loader, no other behavior touched
- [ ] Manually verify `/vacatures/` no longer lists internships for companies with known orphaned records (e.g. search "kaliber", "framna") once deployed to preview